### PR TITLE
[iOS] 차량 요약 컨테이너, 토스트뷰 UI

### DIFF
--- a/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
+++ b/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		763F60402A7B75D1000D11D9 /* CarSummaryContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F603F2A7B75D1000D11D9 /* CarSummaryContainer.swift */; };
 		763F60422A7B9B08000D11D9 /* ContainerStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F60412A7B9B08000D11D9 /* ContainerStackView.swift */; };
 		763F60482A7C7F35000D11D9 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F60472A7C7F35000D11D9 /* ToastView.swift */; };
+		C313500A2A7E826C00D5D401 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31350092A7E826C00D5D401 /* UIImage+.swift */; };
 		D4ACBA442A78A3AD002B6A5B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ACBA432A78A3AD002B6A5B /* AppDelegate.swift */; };
 		D4ACBA462A78A3AD002B6A5B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ACBA452A78A3AD002B6A5B /* SceneDelegate.swift */; };
 		D4ACBA482A78A3AD002B6A5B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ACBA472A78A3AD002B6A5B /* ViewController.swift */; };
@@ -52,6 +53,7 @@
 		763F603F2A7B75D1000D11D9 /* CarSummaryContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarSummaryContainer.swift; sourceTree = "<group>"; };
 		763F60412A7B9B08000D11D9 /* ContainerStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerStackView.swift; sourceTree = "<group>"; };
 		763F60472A7C7F35000D11D9 /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
+		C31350092A7E826C00D5D401 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		D4ACBA402A78A3AD002B6A5B /* TopCariving.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TopCariving.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4ACBA432A78A3AD002B6A5B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D4ACBA452A78A3AD002B6A5B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -207,6 +209,7 @@
 				D4ACBA862A78CE8F002B6A5B /* UIColor+.swift */,
 				D4CFBAAC2A7A25B100CCB27E /* HyundaiFont.swift */,
 				D4CFBAAE2A7A3E6500CCB27E /* UIFont+.swift */,
+				C31350092A7E826C00D5D401 /* UIImage+.swift */,
 			);
 			path = Global;
 			sourceTree = "<group>";
@@ -380,6 +383,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D4ACBA842A78CE62002B6A5B /* DummyViewController.swift in Sources */,
+				C313500A2A7E826C00D5D401 /* UIImage+.swift in Sources */,
 				D4ACBA482A78A3AD002B6A5B /* ViewController.swift in Sources */,
 				D4CFBAAF2A7A3E6500CCB27E /* UIFont+.swift in Sources */,
 				D4ACBA7E2A78CE35002B6A5B /* DummyView.swift in Sources */,

--- a/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
+++ b/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		763F60402A7B75D1000D11D9 /* CarSummaryContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F603F2A7B75D1000D11D9 /* CarSummaryContainer.swift */; };
-		763F60422A7B9B08000D11D9 /* ContainerStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F60412A7B9B08000D11D9 /* ContainerStackView.swift */; };
+		763F60422A7B9B08000D11D9 /* FoldableStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F60412A7B9B08000D11D9 /* FoldableStackView.swift */; };
 		763F60482A7C7F35000D11D9 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F60472A7C7F35000D11D9 /* ToastView.swift */; };
 		C313500A2A7E826C00D5D401 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31350092A7E826C00D5D401 /* UIImage+.swift */; };
 		C313500C2A7E98DE00D5D401 /* FoldableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C313500B2A7E98DE00D5D401 /* FoldableView.swift */; };
@@ -53,7 +53,7 @@
 
 /* Begin PBXFileReference section */
 		763F603F2A7B75D1000D11D9 /* CarSummaryContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarSummaryContainer.swift; sourceTree = "<group>"; };
-		763F60412A7B9B08000D11D9 /* ContainerStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerStackView.swift; sourceTree = "<group>"; };
+		763F60412A7B9B08000D11D9 /* FoldableStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldableStackView.swift; sourceTree = "<group>"; };
 		763F60472A7C7F35000D11D9 /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		C31350092A7E826C00D5D401 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		C313500B2A7E98DE00D5D401 /* FoldableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldableView.swift; sourceTree = "<group>"; };
@@ -203,7 +203,7 @@
 				C313500D2A7FB82B00D5D401 /* TappableView.swift */,
 				C313500B2A7E98DE00D5D401 /* FoldableView.swift */,
 				763F603F2A7B75D1000D11D9 /* CarSummaryContainer.swift */,
-				763F60412A7B9B08000D11D9 /* ContainerStackView.swift */,
+				763F60412A7B9B08000D11D9 /* FoldableStackView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -398,7 +398,7 @@
 				D4CFBAAD2A7A25B100CCB27E /* HyundaiFont.swift in Sources */,
 				D4ACBA872A78CE8F002B6A5B /* UIColor+.swift in Sources */,
 				763F60482A7C7F35000D11D9 /* ToastView.swift in Sources */,
-				763F60422A7B9B08000D11D9 /* ContainerStackView.swift in Sources */,
+				763F60422A7B9B08000D11D9 /* FoldableStackView.swift in Sources */,
 				D4ACBA822A78CE56002B6A5B /* DummyModel.swift in Sources */,
 				C313500C2A7E98DE00D5D401 /* FoldableView.swift in Sources */,
 				763F60402A7B75D1000D11D9 /* CarSummaryContainer.swift in Sources */,

--- a/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
+++ b/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		763F60482A7C7F35000D11D9 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F60472A7C7F35000D11D9 /* ToastView.swift */; };
 		C313500A2A7E826C00D5D401 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31350092A7E826C00D5D401 /* UIImage+.swift */; };
 		C313500C2A7E98DE00D5D401 /* FoldableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C313500B2A7E98DE00D5D401 /* FoldableView.swift */; };
+		C313500E2A7FB82B00D5D401 /* TappableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C313500D2A7FB82B00D5D401 /* TappableView.swift */; };
 		D4ACBA442A78A3AD002B6A5B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ACBA432A78A3AD002B6A5B /* AppDelegate.swift */; };
 		D4ACBA462A78A3AD002B6A5B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ACBA452A78A3AD002B6A5B /* SceneDelegate.swift */; };
 		D4ACBA482A78A3AD002B6A5B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ACBA472A78A3AD002B6A5B /* ViewController.swift */; };
@@ -56,6 +57,7 @@
 		763F60472A7C7F35000D11D9 /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		C31350092A7E826C00D5D401 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		C313500B2A7E98DE00D5D401 /* FoldableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldableView.swift; sourceTree = "<group>"; };
+		C313500D2A7FB82B00D5D401 /* TappableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TappableView.swift; sourceTree = "<group>"; };
 		D4ACBA402A78A3AD002B6A5B /* TopCariving.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TopCariving.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4ACBA432A78A3AD002B6A5B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D4ACBA452A78A3AD002B6A5B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -198,6 +200,7 @@
 			children = (
 				D4ACBA7D2A78CE35002B6A5B /* DummyView.swift */,
 				763F60472A7C7F35000D11D9 /* ToastView.swift */,
+				C313500D2A7FB82B00D5D401 /* TappableView.swift */,
 				C313500B2A7E98DE00D5D401 /* FoldableView.swift */,
 				763F603F2A7B75D1000D11D9 /* CarSummaryContainer.swift */,
 				763F60412A7B9B08000D11D9 /* ContainerStackView.swift */,
@@ -386,6 +389,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D4ACBA842A78CE62002B6A5B /* DummyViewController.swift in Sources */,
+				C313500E2A7FB82B00D5D401 /* TappableView.swift in Sources */,
 				C313500A2A7E826C00D5D401 /* UIImage+.swift in Sources */,
 				D4ACBA482A78A3AD002B6A5B /* ViewController.swift in Sources */,
 				D4CFBAAF2A7A3E6500CCB27E /* UIFont+.swift in Sources */,

--- a/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
+++ b/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		763F60402A7B75D1000D11D9 /* CarSummaryContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F603F2A7B75D1000D11D9 /* CarSummaryContainer.swift */; };
 		D4ACBA442A78A3AD002B6A5B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ACBA432A78A3AD002B6A5B /* AppDelegate.swift */; };
 		D4ACBA462A78A3AD002B6A5B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ACBA452A78A3AD002B6A5B /* SceneDelegate.swift */; };
 		D4ACBA482A78A3AD002B6A5B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ACBA472A78A3AD002B6A5B /* ViewController.swift */; };
@@ -46,6 +47,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		763F603F2A7B75D1000D11D9 /* CarSummaryContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarSummaryContainer.swift; sourceTree = "<group>"; };
 		D4ACBA402A78A3AD002B6A5B /* TopCariving.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TopCariving.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4ACBA432A78A3AD002B6A5B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D4ACBA452A78A3AD002B6A5B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -187,6 +189,7 @@
 			isa = PBXGroup;
 			children = (
 				D4ACBA7D2A78CE35002B6A5B /* DummyView.swift */,
+				763F603F2A7B75D1000D11D9 /* CarSummaryContainer.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -378,6 +381,7 @@
 				D4CFBAAD2A7A25B100CCB27E /* HyundaiFont.swift in Sources */,
 				D4ACBA872A78CE8F002B6A5B /* UIColor+.swift in Sources */,
 				D4ACBA822A78CE56002B6A5B /* DummyModel.swift in Sources */,
+				763F60402A7B75D1000D11D9 /* CarSummaryContainer.swift in Sources */,
 				D4ACBA802A78CE4D002B6A5B /* DummyViewModel.swift in Sources */,
 				D4ACBA462A78A3AD002B6A5B /* SceneDelegate.swift in Sources */,
 			);
@@ -548,7 +552,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = CGUAL476T6;
+				DEVELOPMENT_TEAM = 5R9YHBW9BJ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TopCariving/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -575,7 +579,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = CGUAL476T6;
+				DEVELOPMENT_TEAM = 5R9YHBW9BJ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TopCariving/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
+++ b/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		763F60422A7B9B08000D11D9 /* ContainerStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F60412A7B9B08000D11D9 /* ContainerStackView.swift */; };
 		763F60482A7C7F35000D11D9 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F60472A7C7F35000D11D9 /* ToastView.swift */; };
 		C313500A2A7E826C00D5D401 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31350092A7E826C00D5D401 /* UIImage+.swift */; };
+		C313500C2A7E98DE00D5D401 /* FoldableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C313500B2A7E98DE00D5D401 /* FoldableView.swift */; };
 		D4ACBA442A78A3AD002B6A5B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ACBA432A78A3AD002B6A5B /* AppDelegate.swift */; };
 		D4ACBA462A78A3AD002B6A5B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ACBA452A78A3AD002B6A5B /* SceneDelegate.swift */; };
 		D4ACBA482A78A3AD002B6A5B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ACBA472A78A3AD002B6A5B /* ViewController.swift */; };
@@ -54,6 +55,7 @@
 		763F60412A7B9B08000D11D9 /* ContainerStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerStackView.swift; sourceTree = "<group>"; };
 		763F60472A7C7F35000D11D9 /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		C31350092A7E826C00D5D401 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
+		C313500B2A7E98DE00D5D401 /* FoldableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldableView.swift; sourceTree = "<group>"; };
 		D4ACBA402A78A3AD002B6A5B /* TopCariving.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TopCariving.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4ACBA432A78A3AD002B6A5B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D4ACBA452A78A3AD002B6A5B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -196,6 +198,7 @@
 			children = (
 				D4ACBA7D2A78CE35002B6A5B /* DummyView.swift */,
 				763F60472A7C7F35000D11D9 /* ToastView.swift */,
+				C313500B2A7E98DE00D5D401 /* FoldableView.swift */,
 				763F603F2A7B75D1000D11D9 /* CarSummaryContainer.swift */,
 				763F60412A7B9B08000D11D9 /* ContainerStackView.swift */,
 			);
@@ -393,6 +396,7 @@
 				763F60482A7C7F35000D11D9 /* ToastView.swift in Sources */,
 				763F60422A7B9B08000D11D9 /* ContainerStackView.swift in Sources */,
 				D4ACBA822A78CE56002B6A5B /* DummyModel.swift in Sources */,
+				C313500C2A7E98DE00D5D401 /* FoldableView.swift in Sources */,
 				763F60402A7B75D1000D11D9 /* CarSummaryContainer.swift in Sources */,
 				D4ACBA802A78CE4D002B6A5B /* DummyViewModel.swift in Sources */,
 				D4ACBA462A78A3AD002B6A5B /* SceneDelegate.swift in Sources */,

--- a/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
+++ b/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		763F60402A7B75D1000D11D9 /* CarSummaryContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F603F2A7B75D1000D11D9 /* CarSummaryContainer.swift */; };
+		763F60482A7C7F35000D11D9 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F60472A7C7F35000D11D9 /* ToastView.swift */; };
 		D4ACBA442A78A3AD002B6A5B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ACBA432A78A3AD002B6A5B /* AppDelegate.swift */; };
 		D4ACBA462A78A3AD002B6A5B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ACBA452A78A3AD002B6A5B /* SceneDelegate.swift */; };
 		D4ACBA482A78A3AD002B6A5B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ACBA472A78A3AD002B6A5B /* ViewController.swift */; };
@@ -48,6 +49,7 @@
 
 /* Begin PBXFileReference section */
 		763F603F2A7B75D1000D11D9 /* CarSummaryContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarSummaryContainer.swift; sourceTree = "<group>"; };
+		763F60472A7C7F35000D11D9 /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		D4ACBA402A78A3AD002B6A5B /* TopCariving.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TopCariving.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4ACBA432A78A3AD002B6A5B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D4ACBA452A78A3AD002B6A5B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -189,6 +191,7 @@
 			isa = PBXGroup;
 			children = (
 				D4ACBA7D2A78CE35002B6A5B /* DummyView.swift */,
+				763F60472A7C7F35000D11D9 /* ToastView.swift */,
 				763F603F2A7B75D1000D11D9 /* CarSummaryContainer.swift */,
 			);
 			path = View;
@@ -380,6 +383,7 @@
 				D4ACBA442A78A3AD002B6A5B /* AppDelegate.swift in Sources */,
 				D4CFBAAD2A7A25B100CCB27E /* HyundaiFont.swift in Sources */,
 				D4ACBA872A78CE8F002B6A5B /* UIColor+.swift in Sources */,
+				763F60482A7C7F35000D11D9 /* ToastView.swift in Sources */,
 				D4ACBA822A78CE56002B6A5B /* DummyModel.swift in Sources */,
 				763F60402A7B75D1000D11D9 /* CarSummaryContainer.swift in Sources */,
 				D4ACBA802A78CE4D002B6A5B /* DummyViewModel.swift in Sources */,

--- a/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
+++ b/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		763F60402A7B75D1000D11D9 /* CarSummaryContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F603F2A7B75D1000D11D9 /* CarSummaryContainer.swift */; };
+		763F60422A7B9B08000D11D9 /* ContainerStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F60412A7B9B08000D11D9 /* ContainerStackView.swift */; };
 		763F60482A7C7F35000D11D9 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F60472A7C7F35000D11D9 /* ToastView.swift */; };
 		D4ACBA442A78A3AD002B6A5B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ACBA432A78A3AD002B6A5B /* AppDelegate.swift */; };
 		D4ACBA462A78A3AD002B6A5B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4ACBA452A78A3AD002B6A5B /* SceneDelegate.swift */; };
@@ -49,6 +50,7 @@
 
 /* Begin PBXFileReference section */
 		763F603F2A7B75D1000D11D9 /* CarSummaryContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarSummaryContainer.swift; sourceTree = "<group>"; };
+		763F60412A7B9B08000D11D9 /* ContainerStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerStackView.swift; sourceTree = "<group>"; };
 		763F60472A7C7F35000D11D9 /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		D4ACBA402A78A3AD002B6A5B /* TopCariving.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TopCariving.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4ACBA432A78A3AD002B6A5B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -193,6 +195,7 @@
 				D4ACBA7D2A78CE35002B6A5B /* DummyView.swift */,
 				763F60472A7C7F35000D11D9 /* ToastView.swift */,
 				763F603F2A7B75D1000D11D9 /* CarSummaryContainer.swift */,
+				763F60412A7B9B08000D11D9 /* ContainerStackView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -384,6 +387,7 @@
 				D4CFBAAD2A7A25B100CCB27E /* HyundaiFont.swift in Sources */,
 				D4ACBA872A78CE8F002B6A5B /* UIColor+.swift in Sources */,
 				763F60482A7C7F35000D11D9 /* ToastView.swift in Sources */,
+				763F60422A7B9B08000D11D9 /* ContainerStackView.swift in Sources */,
 				D4ACBA822A78CE56002B6A5B /* DummyModel.swift in Sources */,
 				763F60402A7B75D1000D11D9 /* CarSummaryContainer.swift in Sources */,
 				D4ACBA802A78CE4D002B6A5B /* DummyViewModel.swift in Sources */,

--- a/iOS/TopCariving/TopCariving/Global/UIImage+.swift
+++ b/iOS/TopCariving/TopCariving/Global/UIImage+.swift
@@ -1,0 +1,16 @@
+//
+//  UIImage+.swift
+//  TopCariving
+//
+//  Created by cho seungki on 2023/08/05.
+//
+
+import UIKit
+
+extension UIImage {
+    func resized(to size: CGSize) -> UIImage {
+        UIGraphicsImageRenderer(size: size).image { _ in
+            draw(in: CGRect(origin: .zero, size: size))
+        }
+    }
+}

--- a/iOS/TopCariving/TopCariving/View/CarSummaryContainer.swift
+++ b/iOS/TopCariving/TopCariving/View/CarSummaryContainer.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import Combine
+
 class CarSummaryContainer: FoldableView {
     // MARK: - UI properties
     private let iconStackView = UIStackView()
@@ -39,3 +40,44 @@ class CarSummaryContainer: FoldableView {
         heightConstant?.constant = 215
     }
     
+    func setInfo(to trimName: String, price: String, icons: [(image: URL, text: String)]) {
+        setTitle(to: trimName)
+        setPrice(to: price)
+        icons.forEach { (image, text) in
+            let stackView = UIStackView(arrangedSubviews: [makeIconImageView(by: image), makeIconLabel(by: text)])
+            stackView.axis = .vertical
+            iconStackView.addArrangedSubview(stackView)
+        }
+    }
+    
+    private func makeIconImageView(by url: URL) -> UIImageView {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        #warning("이미지 서비스로 변경")
+        DispatchQueue.global().async {
+            guard let url = try? Data(contentsOf: url) else { return }
+            DispatchQueue.main.async {
+                imageView.image = UIImage(data: url)?.resized(to: .init(width: 40, height: 40))
+            }
+        }
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }
+    
+    private func makeIconLabel(by text: String) -> UILabel {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .designSystem(.init(name: .regular, size: ._14))
+        label.textColor = .hyundaiPrimaryBlue
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .center
+        paragraphStyle.lineHeightMultiple = 1.48
+        label.attributedText = NSMutableAttributedString(
+            string: text,
+            attributes: [NSAttributedString.Key.kern: -0.28, NSAttributedString.Key.paragraphStyle: paragraphStyle]
+        )
+        return label
+    }
+}

--- a/iOS/TopCariving/TopCariving/View/CarSummaryContainer.swift
+++ b/iOS/TopCariving/TopCariving/View/CarSummaryContainer.swift
@@ -1,8 +1,28 @@
 //
-//  CarSummaryContainer.swift
+//  CarSummaryContainerCell.swift
 //  TopCariving
 //
 //  Created by 조승기 on 2023/08/03.
 //
 
-import Foundation
+import UIKit
+import Combine
+class CarSummaryContainer: FoldableView {
+    // MARK: - UI properties
+    private let iconStackView = UIStackView()
+    
+    // MARK: - Helpers
+    override func setUI() {
+        super.setUI()
+        addSubview(iconStackView)
+    }
+    
+    override func setLayout() {
+        super.setLayout()
+        iconStackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            iconStackView.topAnchor.constraint(equalTo: separator.bottomAnchor, constant: 23),
+            iconStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            iconStackView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 1, constant: -40)
+        ])
+    }

--- a/iOS/TopCariving/TopCariving/View/CarSummaryContainer.swift
+++ b/iOS/TopCariving/TopCariving/View/CarSummaryContainer.swift
@@ -1,0 +1,8 @@
+//
+//  CarSummaryContainer.swift
+//  TopCariving
+//
+//  Created by 조승기 on 2023/08/03.
+//
+
+import Foundation

--- a/iOS/TopCariving/TopCariving/View/CarSummaryContainer.swift
+++ b/iOS/TopCariving/TopCariving/View/CarSummaryContainer.swift
@@ -26,3 +26,16 @@ class CarSummaryContainer: FoldableView {
             iconStackView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 1, constant: -40)
         ])
     }
+    
+    override func fold() {
+        super.fold()
+        iconStackView.isHidden = true
+        heightConstant?.constant = 71
+    }
+    
+    override func unfold() {
+        super.unfold()
+        iconStackView.isHidden = false
+        heightConstant?.constant = 215
+    }
+    

--- a/iOS/TopCariving/TopCariving/View/ContainerStackView.swift
+++ b/iOS/TopCariving/TopCariving/View/ContainerStackView.swift
@@ -1,0 +1,9 @@
+//
+//  ContainerStackView.swift
+//  TopCariving
+//
+//  Created by 조승기 on 2023/08/03.
+//
+
+import UIKit
+import Combine

--- a/iOS/TopCariving/TopCariving/View/ContainerStackView.swift
+++ b/iOS/TopCariving/TopCariving/View/ContainerStackView.swift
@@ -12,6 +12,9 @@ class FoldableStackView: UIStackView {
     // MARK: - UI properties
     
     // MARK: - Properties
+    var bag = Set<AnyCancellable>()
+    var tapSubject = PassthroughSubject<Int, Never>()
+
     // MARK: - Lifecycles
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -34,5 +37,32 @@ class FoldableStackView: UIStackView {
         alignment = .fill
         distribution = .equalSpacing
         spacing = 8
+    }
+    
+    override func addArrangedSubview(_ view: UIView) {
+        guard let view = view as? FoldableView else { return }
+        super.addArrangedSubview(view)
+        tapped(at: 0)
+        
+        view.tapSubject
+            .compactMap { [weak self] _ in
+                self?.arrangedSubviews.firstIndex(of: view)
+            }
+            .sink(receiveValue: { [weak self] index in
+                guard let self else { return }
+                tapped(at: index)
+            })
+            .store(in: &bag)
+    }
+    
+    private func tapped(at index: Int) {
+        guard (0..<arrangedSubviews.count) ~= index else { return }
+        
+        arrangedSubviews
+            .compactMap { $0 as? Foldable }
+            .forEach { $0.fold() }
+        (arrangedSubviews[index] as? Foldable)?.unfold()
+        
+        tapSubject.send(index)
     }
 }

--- a/iOS/TopCariving/TopCariving/View/ContainerStackView.swift
+++ b/iOS/TopCariving/TopCariving/View/ContainerStackView.swift
@@ -7,3 +7,32 @@
 
 import UIKit
 import Combine
+
+class FoldableStackView: UIStackView {
+    // MARK: - UI properties
+    
+    // MARK: - Properties
+    // MARK: - Lifecycles
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+    }
+    
+    required init(coder: NSCoder) {
+        super.init(coder: coder)
+        setUI()
+    }
+    
+    convenience init(arrangedSubviews views: [FoldableView]) {
+        self.init(frame: .zero)
+        views.forEach { addArrangedSubview($0) }
+    }
+    
+    // MARK: - Helpers
+    func setUI() {
+        axis = .vertical
+        alignment = .fill
+        distribution = .equalSpacing
+        spacing = 8
+    }
+}

--- a/iOS/TopCariving/TopCariving/View/FoldableStackView.swift
+++ b/iOS/TopCariving/TopCariving/View/FoldableStackView.swift
@@ -1,5 +1,5 @@
 //
-//  ContainerStackView.swift
+//  FoldableStackView.swift
 //  TopCariving
 //
 //  Created by 조승기 on 2023/08/03.

--- a/iOS/TopCariving/TopCariving/View/FoldableView.swift
+++ b/iOS/TopCariving/TopCariving/View/FoldableView.swift
@@ -4,3 +4,14 @@
 //
 //  Created by cho seungki on 2023/08/05.
 //
+
+import UIKit
+import Combine
+
+protocol Foldable {
+    var heightConstant: NSLayoutConstraint? { get set }
+    
+    func fold()
+    func unfold()
+}
+

--- a/iOS/TopCariving/TopCariving/View/FoldableView.swift
+++ b/iOS/TopCariving/TopCariving/View/FoldableView.swift
@@ -1,0 +1,6 @@
+//
+//  FoldableView.swift
+//  TopCariving
+//
+//  Created by cho seungki on 2023/08/05.
+//

--- a/iOS/TopCariving/TopCariving/View/FoldableView.swift
+++ b/iOS/TopCariving/TopCariving/View/FoldableView.swift
@@ -15,7 +15,7 @@ protocol Foldable {
     func unfold()
 }
 
-class FoldableView: UIView, Foldable {
+class FoldableView: TappableView, Foldable {
     // MARK: - UI properties
     private let titleLabel: UILabel = {
         let label = UILabel()
@@ -53,7 +53,6 @@ class FoldableView: UIView, Foldable {
     
     // MARK: - Properties
     var heightConstant: NSLayoutConstraint?
-    var tapSubject = PassthroughSubject<Any, Never>()
     
     // MARK: - Lifecycles
     override init(frame: CGRect) {
@@ -72,17 +71,11 @@ class FoldableView: UIView, Foldable {
     
     // MARK: - Helpers
     func setUI() {
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapped(sender:)))
-        addGestureRecognizer(tapGesture)
         layer.cornerRadius = 8
         
         [titleLabel, priceLabel, wonLabel, separator].forEach {
             addSubview($0)
         }
-    }
-    
-    @objc private func tapped(sender: Any) {
-        tapSubject.send(self)
     }
     
     func setLayout() {

--- a/iOS/TopCariving/TopCariving/View/FoldableView.swift
+++ b/iOS/TopCariving/TopCariving/View/FoldableView.swift
@@ -15,3 +15,105 @@ protocol Foldable {
     func unfold()
 }
 
+class FoldableView: UIView, Foldable {
+    // MARK: - UI properties
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .designSystem(.init(name: .bold, size: ._18))
+        label.textColor = .hyundaiPrimaryBlue
+        return label
+    }()
+    
+    private let priceLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .designSystem(.init(name: .bold, size: ._18))
+        label.textColor = .hyundaiPrimaryBlue
+        label.textAlignment = .right
+        return label
+    }()
+    
+    private let wonLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .designSystem(.init(name: .regular, size: ._12))
+        label.text = "원"
+        label.textColor = .hyundaiPrimaryBlue
+        return label
+    }()
+    
+    let separator: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.borderColor = UIColor(red: 0, green: 0.173, blue: 0.373, alpha: 0.6).cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+    
+    // MARK: - Properties
+    var heightConstant: NSLayoutConstraint?
+    // MARK: - Lifecycles
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+        setLayout()
+        unfold()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setUI()
+        setLayout()
+        unfold()
+    }
+    
+    // MARK: - Helpers
+    func setUI() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapped(sender:)))
+        addGestureRecognizer(tapGesture)
+        layer.cornerRadius = 8
+        
+        [titleLabel, priceLabel, wonLabel, separator].forEach {
+            addSubview($0)
+        }
+    }
+    func setLayout() {
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        heightConstant = heightAnchor.constraint(equalToConstant: 71)
+        heightConstant?.isActive = true
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: 25),
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+            titleLabel.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 0.5),
+            titleLabel.heightAnchor.constraint(equalToConstant: 27),
+            
+            wonLabel.topAnchor.constraint(equalTo: topAnchor, constant: 28),
+            wonLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
+            wonLabel.heightAnchor.constraint(equalToConstant: 22),
+            wonLabel.widthAnchor.constraint(equalToConstant: 15),
+            
+            priceLabel.topAnchor.constraint(equalTo: topAnchor, constant: 23),
+            priceLabel.leadingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+            priceLabel.trailingAnchor.constraint(equalTo: wonLabel.leadingAnchor, constant: -4),
+            priceLabel.heightAnchor.constraint(equalToConstant: 31),
+            
+            separator.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 12),
+            separator.heightAnchor.constraint(equalToConstant: 1),
+            separator.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+            separator.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20)
+        ])
+    }
+    
+    func fold() {
+        separator.isHidden = true
+        layer.borderWidth = 0
+        backgroundColor = UIColor.hyundaiLightSand
+    }
+    
+    func unfold() {
+        separator.isHidden = false
+        layer.borderWidth = 1
+        layer.borderColor = UIColor(red: 0, green: 0.173, blue: 0.373, alpha: 0.6).cgColor
+        backgroundColor = UIColor(red: 0, green: 0.173, blue: 0.373, alpha: 0.1)
+    }

--- a/iOS/TopCariving/TopCariving/View/FoldableView.swift
+++ b/iOS/TopCariving/TopCariving/View/FoldableView.swift
@@ -124,3 +124,12 @@ class FoldableView: UIView, Foldable {
         layer.borderColor = UIColor(red: 0, green: 0.173, blue: 0.373, alpha: 0.6).cgColor
         backgroundColor = UIColor(red: 0, green: 0.173, blue: 0.373, alpha: 0.1)
     }
+    
+    func setTitle(to title: String) {
+        titleLabel.text = title
+    }
+    
+    func setPrice(to price: String) {
+        priceLabel.text = price
+    }
+}

--- a/iOS/TopCariving/TopCariving/View/FoldableView.swift
+++ b/iOS/TopCariving/TopCariving/View/FoldableView.swift
@@ -53,6 +53,8 @@ class FoldableView: UIView, Foldable {
     
     // MARK: - Properties
     var heightConstant: NSLayoutConstraint?
+    var tapSubject = PassthroughSubject<Any, Never>()
+    
     // MARK: - Lifecycles
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -78,6 +80,11 @@ class FoldableView: UIView, Foldable {
             addSubview($0)
         }
     }
+    
+    @objc private func tapped(sender: Any) {
+        tapSubject.send(self)
+    }
+    
     func setLayout() {
         separator.translatesAutoresizingMaskIntoConstraints = false
         heightConstant = heightAnchor.constraint(equalToConstant: 71)

--- a/iOS/TopCariving/TopCariving/View/TappableView.swift
+++ b/iOS/TopCariving/TopCariving/View/TappableView.swift
@@ -1,0 +1,29 @@
+//
+//  TappableView.swift
+//  TopCariving
+//
+//  Created by cho seungki on 2023/08/06.
+//
+
+import UIKit
+import Combine
+
+class TappableView: UIView {
+    var tapSubject = PassthroughSubject<Any, Never>()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapped(sender:)))
+        addGestureRecognizer(tapGesture)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapped(sender:)))
+        addGestureRecognizer(tapGesture)
+    }
+    
+    @objc private func tapped(sender: Any) {
+        tapSubject.send(self)
+    }
+}

--- a/iOS/TopCariving/TopCariving/View/ToastView.swift
+++ b/iOS/TopCariving/TopCariving/View/ToastView.swift
@@ -5,8 +5,81 @@
 //  Created by 조승기 on 2023/08/04.
 //
 
-import Foundation
+import UIKit
+import Combine
 
-//class ToastView: UIView {
-//
-//}
+class ToastView: UIView {
+    // MARK: - UI Property
+    private let contentView = {
+        let view = UIView()
+        view.backgroundColor = .hyundaiBlackGray.withAlphaComponent(0.5)
+        view.layer.cornerRadius = 4
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let closeButton = {
+        let button = UIButton(type: .close)
+        button.setTitleColor(UIColor.hyundaiLightSand, for: .normal)
+        return button
+    }()
+    
+    private let messageLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .hyundaiLightSand
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .designSystem(.init(name: .regular, size: ._12))
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .center
+        paragraphStyle.lineHeightMultiple = 1.57
+        label.attributedText = NSMutableAttributedString(
+            string: "옵션 선택이 고민되신다면, 아카이\n빙에서 다른 차량을 구경해보세요!",
+            attributes: [NSAttributedString.Key.kern: -0.24, NSAttributedString.Key.paragraphStyle: paragraphStyle]
+        )
+        return label
+    }()
+    
+    // MARK: - Property
+    private let padding = 10.0
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setUI()
+        setLayout()
+    }
+    
+    func setUI() {
+        backgroundColor = .clear
+        addSubview(contentView)
+        [closeButton, messageLabel].forEach {
+            contentView.addSubview($0)
+        }
+    }
+    
+    func setLayout() {
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            contentView.topAnchor.constraint(equalTo: topAnchor, constant: padding),
+            contentView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -padding),
+            contentView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: padding),
+            contentView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -padding),
+            
+            closeButton.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10),
+            closeButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -13),
+            closeButton.widthAnchor.constraint(equalToConstant: 7.5),
+            closeButton.heightAnchor.constraint(equalToConstant: 7.5),
+            
+            messageLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10),
+            messageLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10),
+            messageLabel.trailingAnchor.constraint(equalTo: closeButton.leadingAnchor, constant: -13),
+            messageLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 13)
+        ])
+    }
+}

--- a/iOS/TopCariving/TopCariving/View/ToastView.swift
+++ b/iOS/TopCariving/TopCariving/View/ToastView.swift
@@ -43,6 +43,13 @@ class ToastView: UIView {
     
     // MARK: - Property
     private let padding = 10.0
+    var sourceRect: CGRect?
+    private var triangleStartX: Double {
+        guard let sourceRect else { return frame.width / 2.0 }
+        if frame.maxX - 5 < sourceRect.midX { return frame.maxX - 10.0 }
+        if frame.minX + 5 > sourceRect.midX { return frame.minX }
+        return abs(frame.minX - sourceRect.midX + 5)
+    }
     let tapCloseButtonSubject = PassthroughSubject<Any, Never>()
     
     // MARK: - LifeCycle
@@ -59,6 +66,31 @@ class ToastView: UIView {
         setLayout()
         setEvent()
     }
+    
+    override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        drawTriangle()
+    }
+    
+    // MARK: - Helper
+    private func drawTriangle() {
+        let path = UIBezierPath()
+        let startPoint = CGPoint(x: triangleStartX, y: padding)
+        path.move(to: startPoint)
+        
+        let leftTopPoint = startPoint.applying(.init(translationX: 4, y: -7))
+        path.addLine(to: leftTopPoint)
+        
+        let rightTopPoint = leftTopPoint.applying(.init(translationX: 2, y: 0))
+        let controlPoint = leftTopPoint.applying(.init(translationX: 1, y: -2))
+        path.addQuadCurve(to: rightTopPoint, controlPoint: controlPoint)
+
+        let endPoint = CGPoint(x: startPoint.x + 10, y: padding)
+        path.addLine(to: endPoint)
+        
+        path.close()
+        UIColor.hyundaiBlackGray.withAlphaComponent(0.5).set()
+        path.fill()
     }
     
     func setUI() {

--- a/iOS/TopCariving/TopCariving/View/ToastView.swift
+++ b/iOS/TopCariving/TopCariving/View/ToastView.swift
@@ -1,0 +1,12 @@
+//
+//  ToastView.swift
+//  TopCariving
+//
+//  Created by 조승기 on 2023/08/04.
+//
+
+import Foundation
+
+//class ToastView: UIView {
+//
+//}

--- a/iOS/TopCariving/TopCariving/View/ToastView.swift
+++ b/iOS/TopCariving/TopCariving/View/ToastView.swift
@@ -43,16 +43,22 @@ class ToastView: UIView {
     
     // MARK: - Property
     private let padding = 10.0
+    let tapCloseButtonSubject = PassthroughSubject<Any, Never>()
+    
+    // MARK: - LifeCycle
     override init(frame: CGRect) {
         super.init(frame: frame)
         setUI()
         setLayout()
+        setEvent()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         setUI()
         setLayout()
+        setEvent()
+    }
     }
     
     func setUI() {
@@ -81,5 +87,13 @@ class ToastView: UIView {
             messageLabel.trailingAnchor.constraint(equalTo: closeButton.leadingAnchor, constant: -13),
             messageLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 13)
         ])
+    }
+    
+    func setEvent() {
+        closeButton.addTarget(self, action: #selector(tapCloseButton(sender:)), for: .touchUpInside)
+    }
+    
+    @objc private func tapCloseButton(sender: UIButton) {
+        tapCloseButtonSubject.send(self)
     }
 }


### PR DESCRIPTION
## 🔥 요약
![image](https://github.com/softeerbootcamp-2nd/H4-TopCariving/assets/57134892/3405c417-04be-42fd-ad84-d4c81a87e83e)

## ✏️ 작업 내용

### 차량 요약 컨테이너

- Foldable, FoldableView 작성
    ```swift
    protocol Foldable {
        var heightConstant: NSLayoutConstraint? { get set }
    
        func fold()
        func unfold()
    }

    class FoldableView: TappableView, Foldable {}
    ```

    <img width="356" alt="image" src="https://github.com/softeerbootcamp-2nd/H4-TopCariving/assets/57134892/b87a05c0-8e78-446a-9b21-2319cd87d2b4">

    - 사진과 같이 엔진, 이어서 바디타입 구동 방식에서도 비슷한 로직을 모았습니다.
    - tapSubject를 들고있고, fold() unfold() 메소드에 맞춰서 뷰를 변경합니다.

- CarSummaryContainer
    - FoldableView를 상속받아서 작성했습니다.

- FoldableStackView
    - FoldableView들을 관리하기 위해서 작성했습니다. 
    - 탭 제스쳐가 foldableView에서 올라오면, 올라온 뷰만 unfold하고 나머지 뷰는 fold합니다.


### 토스트 뷰

- 삐죽 튀어나온 화살표를 표시하기 위해 베지어 패스를 사용했습니다.
    - 노션에 정리했습니다.

## 📖 질문 사항

closes #29
closes #70 
