### PR TITLE
[iOS] Alert View 구현

### DIFF
--- a/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
+++ b/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		763F60402A7B75D1000D11D9 /* CarSummaryContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F603F2A7B75D1000D11D9 /* CarSummaryContainer.swift */; };
 		763F60422A7B9B08000D11D9 /* FoldableStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F60412A7B9B08000D11D9 /* FoldableStackView.swift */; };
 		763F60482A7C7F35000D11D9 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F60472A7C7F35000D11D9 /* ToastView.swift */; };
+		76CA13AE2A8DE64E006C3106 /* TCAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76CA13AD2A8DE64E006C3106 /* TCAlertViewController.swift */; };
 		C313500A2A7E826C00D5D401 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31350092A7E826C00D5D401 /* UIImage+.swift */; };
 		C313500C2A7E98DE00D5D401 /* FoldableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C313500B2A7E98DE00D5D401 /* FoldableView.swift */; };
 		C313500E2A7FB82B00D5D401 /* TappableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C313500D2A7FB82B00D5D401 /* TappableView.swift */; };
@@ -132,6 +133,7 @@
 		763F603F2A7B75D1000D11D9 /* CarSummaryContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarSummaryContainer.swift; sourceTree = "<group>"; };
 		763F60412A7B9B08000D11D9 /* FoldableStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldableStackView.swift; sourceTree = "<group>"; };
 		763F60472A7C7F35000D11D9 /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
+		76CA13AD2A8DE64E006C3106 /* TCAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCAlertViewController.swift; sourceTree = "<group>"; };
 		C31350092A7E826C00D5D401 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		C313500B2A7E98DE00D5D401 /* FoldableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldableView.swift; sourceTree = "<group>"; };
 		C313500D2A7FB82B00D5D401 /* TappableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TappableView.swift; sourceTree = "<group>"; };
@@ -433,6 +435,7 @@
 				7631E94A2A8382E100015363 /* BaseMyCarViewController.swift */,
 				D4ACBA832A78CE62002B6A5B /* DummyViewController.swift */,
 				D462E76B2A850D3F00C5A8EC /* IncludedBaseItemModalViewController.swift */,
+				76CA13AD2A8DE64E006C3106 /* TCAlertViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -723,6 +726,7 @@
 				D4ACBA802A78CE4D002B6A5B /* ViewModelProtocol.swift in Sources */,
 				763F60482A7C7F35000D11D9 /* ToastView.swift in Sources */,
 				7631E9432A81D3CF00015363 /* CTAButton.swift in Sources */,
+				76CA13AE2A8DE64E006C3106 /* TCAlertViewController.swift in Sources */,
 				D462E81C2A8A700E00C5A8EC /* BaseOptonSubCategoryCell.swift in Sources */,
 				763F60422A7B9B08000D11D9 /* FoldableStackView.swift in Sources */,
 				D4ACBA822A78CE56002B6A5B /* DummyModel.swift in Sources */,

--- a/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
+++ b/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		763F60422A7B9B08000D11D9 /* FoldableStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F60412A7B9B08000D11D9 /* FoldableStackView.swift */; };
 		763F60482A7C7F35000D11D9 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F60472A7C7F35000D11D9 /* ToastView.swift */; };
 		76CA13AE2A8DE64E006C3106 /* TCAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76CA13AD2A8DE64E006C3106 /* TCAlertViewController.swift */; };
+		76CA13B42A8E062B006C3106 /* NSAttributedString+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76CA13B32A8E062B006C3106 /* NSAttributedString+.swift */; };
 		C313500A2A7E826C00D5D401 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31350092A7E826C00D5D401 /* UIImage+.swift */; };
 		C313500C2A7E98DE00D5D401 /* FoldableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C313500B2A7E98DE00D5D401 /* FoldableView.swift */; };
 		C313500E2A7FB82B00D5D401 /* TappableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C313500D2A7FB82B00D5D401 /* TappableView.swift */; };
@@ -134,6 +135,7 @@
 		763F60412A7B9B08000D11D9 /* FoldableStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldableStackView.swift; sourceTree = "<group>"; };
 		763F60472A7C7F35000D11D9 /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		76CA13AD2A8DE64E006C3106 /* TCAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCAlertViewController.swift; sourceTree = "<group>"; };
+		76CA13B32A8E062B006C3106 /* NSAttributedString+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+.swift"; sourceTree = "<group>"; };
 		C31350092A7E826C00D5D401 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		C313500B2A7E98DE00D5D401 /* FoldableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldableView.swift; sourceTree = "<group>"; };
 		C313500D2A7FB82B00D5D401 /* TappableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TappableView.swift; sourceTree = "<group>"; };
@@ -486,6 +488,7 @@
 				D462E7772A852D3C00C5A8EC /* UIGestureRecognizer+.swift */,
 				D462E77F2A85F3D900C5A8EC /* UIView+.swift */,
 				7625A8002A8A26AA0060EEF5 /* String+.swift */,
+				76CA13B32A8E062B006C3106 /* NSAttributedString+.swift */,
 			);
 			path = Global;
 			sourceTree = "<group>";
@@ -689,6 +692,7 @@
 				D44B45752A7BC3DF00E8E207 /* DummyViewModel.swift in Sources */,
 				D462E77E2A85CCA900C5A8EC /* CombineGestureEvent.swift in Sources */,
 				7631E95D2A891A7B00015363 /* OptionDescriptionCell.swift in Sources */,
+				76CA13B42A8E062B006C3106 /* NSAttributedString+.swift in Sources */,
 				7631E94B2A8382E100015363 /* BaseMyCarViewController.swift in Sources */,
 				D44B45952A7CB9CA00E8E207 /* APIEndPoints.swift in Sources */,
 				D4A68D402A80F0EE00E2C1FD /* Color.swift in Sources */,

--- a/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
+++ b/iOS/TopCariving/TopCariving.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		763F60422A7B9B08000D11D9 /* FoldableStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F60412A7B9B08000D11D9 /* FoldableStackView.swift */; };
 		763F60482A7C7F35000D11D9 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763F60472A7C7F35000D11D9 /* ToastView.swift */; };
 		76CA13AE2A8DE64E006C3106 /* TCAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76CA13AD2A8DE64E006C3106 /* TCAlertViewController.swift */; };
+		76CA13B22A8E0135006C3106 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76CA13B12A8E0135006C3106 /* UIViewController+.swift */; };
 		76CA13B42A8E062B006C3106 /* NSAttributedString+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76CA13B32A8E062B006C3106 /* NSAttributedString+.swift */; };
 		C313500A2A7E826C00D5D401 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31350092A7E826C00D5D401 /* UIImage+.swift */; };
 		C313500C2A7E98DE00D5D401 /* FoldableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C313500B2A7E98DE00D5D401 /* FoldableView.swift */; };
@@ -135,6 +136,7 @@
 		763F60412A7B9B08000D11D9 /* FoldableStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldableStackView.swift; sourceTree = "<group>"; };
 		763F60472A7C7F35000D11D9 /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		76CA13AD2A8DE64E006C3106 /* TCAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCAlertViewController.swift; sourceTree = "<group>"; };
+		76CA13B12A8E0135006C3106 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		76CA13B32A8E062B006C3106 /* NSAttributedString+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+.swift"; sourceTree = "<group>"; };
 		C31350092A7E826C00D5D401 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		C313500B2A7E98DE00D5D401 /* FoldableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldableView.swift; sourceTree = "<group>"; };
@@ -488,6 +490,7 @@
 				D462E7772A852D3C00C5A8EC /* UIGestureRecognizer+.swift */,
 				D462E77F2A85F3D900C5A8EC /* UIView+.swift */,
 				7625A8002A8A26AA0060EEF5 /* String+.swift */,
+				76CA13B12A8E0135006C3106 /* UIViewController+.swift */,
 				76CA13B32A8E062B006C3106 /* NSAttributedString+.swift */,
 			);
 			path = Global;
@@ -737,6 +740,7 @@
 				D462E85A2A8B79C300C5A8EC /* BaseOptonMainCategoryModel.swift in Sources */,
 				C313500C2A7E98DE00D5D401 /* FoldableView.swift in Sources */,
 				763F60402A7B75D1000D11D9 /* CarSummaryContainer.swift in Sources */,
+				76CA13B22A8E0135006C3106 /* UIViewController+.swift in Sources */,
 				D4ACBA802A78CE4D002B6A5B /* ViewModelProtocol.swift in Sources */,
 				7631E9612A89A0C400015363 /* OptionDescriptionView.swift in Sources */,
 				D4ACBA462A78A3AD002B6A5B /* SceneDelegate.swift in Sources */,
@@ -922,6 +926,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -950,6 +955,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/iOS/TopCariving/TopCariving/Global/NSAttributedString+.swift
+++ b/iOS/TopCariving/TopCariving/Global/NSAttributedString+.swift
@@ -1,0 +1,24 @@
+//
+//  NSAttributedString+.swift
+//  TopCariving
+//
+//  Created by 조승기 on 2023/08/17.
+//
+
+import UIKit
+
+extension NSAttributedString {
+    static func makeBold(
+        _ text: String,
+        boldText: String,
+        font: HyundaiFont.Custom,
+        boldFont: HyundaiFont.Custom
+    ) -> NSAttributedString {
+        let attributedString = NSMutableAttributedString(string: text, attributes: [.font: UIFont.designSystem(font)])
+        attributedString.addAttribute(.font,
+                                      value: UIFont.designSystem(boldFont),
+                                      range: (text as NSString).range(of: boldText))
+        
+        return attributedString
+    }
+}

--- a/iOS/TopCariving/TopCariving/Global/UIColor+.swift
+++ b/iOS/TopCariving/TopCariving/Global/UIColor+.swift
@@ -33,4 +33,5 @@ extension UIColor {
     static let hyundaiBrownAlert = UIColor(red: 86/255, green: 28/255, blue: 22/255, alpha: 1.0)
     
     static let hyundaiActiveBlue = UIColor(red: 0/255, green: 170/255, blue: 210/255, alpha: 1.0)
+    static let hyundaiDim = UIColor(red: 35/255, green: 35/255, blue: 35/255, alpha: 0.6)
 }

--- a/iOS/TopCariving/TopCariving/Global/UIViewController+.swift
+++ b/iOS/TopCariving/TopCariving/Global/UIViewController+.swift
@@ -1,0 +1,26 @@
+//
+//  UIViewController+.swift
+//  TopCariving
+//
+//  Created by 조승기 on 2023/08/17.
+//
+
+import UIKit
+
+extension UIViewController {
+    func showAlert(
+        with attributedString: NSAttributedString,
+        acceptTitle: String,
+        acceptHandler: @escaping () -> Void
+    ) {
+        let alertViewController = TCAlertViewController()
+        alertViewController.setUp(
+            with: attributedString,
+            acceptTitle: acceptTitle,
+            acceptHandler: acceptHandler
+        )
+
+        alertViewController.modalPresentationStyle = .overFullScreen
+        self.present(alertViewController, animated: false)
+    }
+}

--- a/iOS/TopCariving/TopCariving/ViewController/TCAlertViewController.swift
+++ b/iOS/TopCariving/TopCariving/ViewController/TCAlertViewController.swift
@@ -1,0 +1,8 @@
+//
+//  TCAlertViewController.swift
+//  TopCariving
+//
+//  Created by 조승기 on 2023/08/17.
+//
+
+import Foundation

--- a/iOS/TopCariving/TopCariving/ViewController/TCAlertViewController.swift
+++ b/iOS/TopCariving/TopCariving/ViewController/TCAlertViewController.swift
@@ -5,4 +5,118 @@
 //  Created by 조승기 on 2023/08/17.
 //
 
-import Foundation
+import Combine
+import UIKit
+
+class TCAlertViewController: UIViewController {
+    // MARK: - UI properties
+    private let dimBackgroundView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .hyundaiDim
+        return view
+    }()
+    private let alertView = {
+        let view = UIView()
+        view.layer.cornerRadius = 8
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .white
+        return view
+    }()
+    private let descriptionLabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.setFont(to: .init(name: .regular, size: ._14))
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        return label
+    }()
+    private let cancelButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.layer.cornerRadius = 8
+        button.titleLabel?.font = .designSystem(.init(name: .bold, size: ._18))
+        button.setTitle("취소", for: .normal)
+        button.backgroundColor = .hyundaiLightGray
+        return button
+    }()
+    private let acceptButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.layer.cornerRadius = 8
+        button.titleLabel?.font = .designSystem(.init(name: .bold, size: ._18))
+        button.backgroundColor = .hyundaiPrimaryBlue
+        return button
+    }()
+    
+    // MARK: - Properties
+    private var bag = Set<AnyCancellable>()
+    private var acceptHandler: (() -> Void)?
+    
+    // MARK: - Lifecycles
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUI()
+        setLayout()
+        setEvent()
+    }
+    // MARK: - Helpers
+    private func setUI() {
+        [dimBackgroundView, alertView, descriptionLabel, cancelButton, acceptButton].forEach {
+            view.addSubview($0)
+        }
+    }
+    private func setLayout() {
+        NSLayoutConstraint.activate([
+            dimBackgroundView.topAnchor.constraint(equalTo: view.topAnchor),
+            dimBackgroundView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            dimBackgroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            dimBackgroundView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            
+            alertView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            alertView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            alertView.heightAnchor.constraint(equalToConstant: 186),
+            alertView.widthAnchor.constraint(equalTo: view.widthAnchor, constant: -32),
+            
+            descriptionLabel.centerYAnchor.constraint(equalTo: alertView.centerYAnchor, constant: -35),
+            descriptionLabel.leadingAnchor.constraint(equalTo: alertView.leadingAnchor, constant: 16),
+            descriptionLabel.trailingAnchor.constraint(equalTo: alertView.trailingAnchor, constant: -16),
+            
+            cancelButton.leadingAnchor.constraint(equalTo: alertView.leadingAnchor, constant: 12),
+            cancelButton.trailingAnchor.constraint(equalTo: alertView.centerXAnchor, constant: -3),
+            cancelButton.bottomAnchor.constraint(equalTo: alertView.bottomAnchor, constant: -13),
+            cancelButton.heightAnchor.constraint(equalToConstant: 56),
+            
+            acceptButton.leadingAnchor.constraint(equalTo: alertView.centerXAnchor, constant: 3),
+            acceptButton.trailingAnchor.constraint(equalTo: alertView.trailingAnchor, constant: -13),
+            acceptButton.bottomAnchor.constraint(equalTo: alertView.bottomAnchor, constant: -13),
+            acceptButton.heightAnchor.constraint(equalToConstant: 56)
+        ])
+    }
+    private func setEvent() {
+        Publishers.Merge(dimBackgroundView.tabPublisher.map { _ in () },
+                         cancelButton.touchUpPublisher)
+        .sink(receiveValue: { [weak self] in
+            guard let self else { return }
+            self.dismiss(animated: false)
+        })
+        .store(in: &bag)
+        
+        acceptButton.tapPublisher()
+            .sink(receiveValue: { [weak self] in
+                guard let self else { return }
+                self.acceptHandler?()
+                self.dismiss(animated: false)
+            })
+            .store(in: &bag)
+    }
+    func setUp(
+        with attributedString: NSAttributedString,
+        acceptTitle: String,
+        acceptHandler: @escaping () -> Void
+    ) {
+        self.acceptHandler = acceptHandler
+        descriptionLabel.attributedText = attributedString
+        acceptButton.setTitle(acceptTitle, for: .normal)
+    }
+}

--- a/iOS/TopCariving/TopCariving/ViewController/ViewController.swift
+++ b/iOS/TopCariving/TopCariving/ViewController/ViewController.swift
@@ -9,32 +9,37 @@ import Combine
 import UIKit
 
 class ViewController: BaseMyCarViewController {
-    private var asd = Set<AnyCancellable>()
-    let modalVC = IncludedBaseItemModalViewController()
+    // MARK: - Properties
+    var bag = Set<AnyCancellable>()
+    var myView: UIView = {
+        var view: UIView = UIView(frame: .init(x: 100, y: 150, width: 200, height: 200))
+        view.backgroundColor = .red
+        return view
+    }()
+    
+    // MARK: - Lifecycles
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        view.backgroundColor = .white
-        let uiView = UIView(frame: .init(x: 100, y: 300, width: 200, height: 200))
-        
-        uiView.backgroundColor = .hyundaiBlackGray
-        view.addSubview(uiView)
-        uiView.tabPublisher.sink { _ in
-            self.modalVC.modalPresentationStyle = .automatic
-            self.present(self.modalVC, animated: true)
-        }.store(in: &asd)
-    }
-    
-    // data는 OptionSelectViewDataSource를 위한 데이터 소스 입니다.
-    var data = (0..<6).map { OptionCardViewModel.init(image: "TopArchivingButton", name: "컴포트 \($0)", price: 400000, isAdded: false) }
-}
+        view.addSubview(myView)
 
-extension ViewController: OptionSelectViewDataSource {
-    func numberOfOption(_ optionSelectView: OptionSelectView) -> Int {
-        5
-    }
-    func optionSelectViewModel(_ optionSelectView: OptionSelectView, at indexPath: IndexPath) -> OptionCardViewModel {
-        data[indexPath.row]
+        view.backgroundColor = .white
+        
+        myView.tabPublisher.sink { [weak self] _ in
+            guard let self else { return }
+            self.testAlert()
+        }.store(in: &bag)
     }
     
+    private func testAlert() {
+        let text = "내 차 만들기를 그만하시겠어요?\n 만들던 차량은 아카이빙>내가 만든 차량 에\n 저장해둘게요"
+        let boldText = "아카이빙>내가 만든 차량"
+        showAlert(with: .makeBold(text,
+                                  boldText: boldText,
+                                  font: .init(name: .regular, size: ._14),
+                                  boldFont: .init(name: .medium, size: ._14)),
+                  acceptTitle: "내 차 만들기 종료",
+                  acceptHandler: {
+            print("HI")
+        })
+    }
 }


### PR DESCRIPTION
## 🔥 요약
![image](https://github.com/softeerbootcamp-2nd/H4-TopCariving/assets/57134892/0d2ae665-b320-44ba-ae0d-e63be21c7c79)

## ✏️ 작업 내용
- TCAlertViewController
    - 뷰로 할 경우 네비게이션 타이틀 아래로 가는 이슈로 뷰컨으로 구현했습니다.
- UIViewController+
    - 편의를 위해 extensino 메소드 추가했습니다.
    ```swift
    func showAlert(
        with attributedString: NSAttributedString,
        acceptTitle: String,
        acceptHandler: @escaping () -> Void
    )
    ```
    - Alert의 경우 피그마에서 대부분 부분 볼드가 있어, attributedString으로 받습니다.
- NSAttributedString+
    - 부분 볼드 AttributedString을 구현했습니다.
## 📖 질문 사항
